### PR TITLE
feat(types): add TypeScript type definitions

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1,0 +1,64 @@
+import type { Emitter } from 'mitt'
+
+export interface MetatagsRule {
+  selector: string
+  attr?: string
+  validator: (opts: { value: string; el: unknown }) => Promise<void>
+  status?: 'success' | string
+  message?: string
+  value?: string
+}
+
+export interface MetatagsReport {
+  [key: string]: MetatagsRule[]
+}
+
+export interface FetchedData {
+  html: string
+  targetUrl: string
+  [key: string]: unknown
+}
+
+export interface MetatagsOptions {
+  /**
+   * Custom emitter instance for listening to events
+   * @default mitt()
+   */
+  emitter?: Emitter<MetatagsEvents>
+  /**
+   * Number of concurrent requests
+   * @default 8
+   */
+  concurrence?: number
+  /**
+   * Custom browserless instance
+   */
+  getBrowserless?: unknown
+  /**
+   * Additional options passed to html-get
+   */
+  [key: string]: unknown
+}
+
+export interface MetatagsEvents {
+  urls: string[]
+  fetching: { url: string }
+  fetched: FetchedData
+  rule: MetatagsRule
+  report: MetatagsReport
+  end: MetatagsReport
+  error: Error
+}
+
+/**
+ * Validate meta tags across multiple URLs
+ * @param urls - Single URL or array of URLs to validate
+ * @param options - Configuration options
+ * @returns Emitter instance for listening to validation events
+ */
+export function metatags(
+  urls: string | string[],
+  options?: MetatagsOptions
+): Emitter<MetatagsEvents>
+
+export default metatags

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,8 @@
     "xml-urls": "~2.1.25"
   },
   "files": [
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "scripts": {
     "test": "exit 0"
@@ -47,5 +48,6 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
This PR adds TypeScript type definitions to @metatags/core, enabling TypeScript users to use this module with full type support.

## Changes
- Added `index.d.ts` with type definitions for the metatags function
- Added `types` field to package.json to expose types to consumers
- Added index.d.ts to files array

## Types Added
- `MetatagsRule` interface for rule definitions
- `MetatagsReport` interface for validation report results
- `MetatagsOptions` interface for function options (emitter, concurrence, getBrowserless)
- `MetatagsEvents` interface for emitted events (urls, fetching, fetched, rule, report, end, error)
- `metatags` function with full type signatures

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*